### PR TITLE
Fix outdated CV links

### DIFF
--- a/index.html
+++ b/index.html
@@ -389,7 +389,7 @@
                     </a>
                 </li>
                 <li class="inset-container outline-item d-flex">
-                    <a class="btn icon-download outset-container-2 flex-fill" href="assets/images/SANEZ_CV_2021.pdf"
+                    <a class="btn icon-download outset-container-2 flex-fill" href="assets/images/SANEZ_CV_20241228.pdf"
                        download>
                         <span class="inset-inner">
                             <i class="social-icon cta-icon icon-download fa fa-download">
@@ -499,7 +499,7 @@
                          </span><!--/github -->
                          <!-- CV Download -->
                          <span class="ribbon-fragment ribbon-close d-none d-sm-flex d-md-none d-lg-flex">
-                             <a class="d-flex" href="assets/images/SANEZ_CV_2021.pdf" download>
+                             <a class="d-flex" href="assets/images/SANEZ_CV_20241228.pdf" download>
                                  <i class="text-dark far fa-file-pdf pr-1" aria-hidden="true"></i>
                                  <span class="sr-only">Download my CV</span>
                                  sanez_cv_2021.<span class="text-lowercase">pdf</span>
@@ -514,10 +514,10 @@
                     <span class="outset-container-2 contact-text flex-fill mr-2 text-muted justify-content-between align-middle">
                         <span class="value" aria-label="file name">
                             <i class="far fa-file-pdf pr-1" aria-hidden="true"></i>
-                            sanez_cv_2021.pdf
+                            sanez_cv_20241228.pdf
                         </span>
                     </span>
-                    <a class="outset-container-2 btn" href="assets/images/SANEZ_CV_2021.pdf" download>
+                    <a class="outset-container-2 btn" href="assets/images/SANEZ_CV_20241228.pdf" download>
                         <span class="inset-inner">
                             <i class="icon-landing fas fa-download" aria-hidden="true"></i>
                             <span class="sr-only">Download my CV</span>
@@ -627,7 +627,7 @@
                                 </li>
                                 <li class="list-inline-item">
                                     <a class="btn social-download outset-container-2"
-                                       href="assets/images/SANEZ_CV_2021.pdf" target="_blank">
+                                       href="assets/images/SANEZ_CV_20241228.pdf" target="_blank">
                                     <span class="inset-inner">
                                             <i class="social-icon social-download fa fa-download">
                                                 <span class="sr-only">Open PDF of CV</span>
@@ -1313,7 +1313,7 @@
                                         </small>
                                      </span>
                                     <a class="outset-container-2 btn"
-                                       href="assets/images/SANEZ_CV_2021.pdf" download>
+                                       href="assets/images/SANEZ_CV_20241228.pdf" download>
                                         <span class="inset-inner">
                                             <i class="icon-cta icon-download fa fa-download"></i>
                                             <span class="sr-only">Save my CV</span>


### PR DESCRIPTION
## Summary
- link to the updated SANEZ_CV_20241228.pdf in all CV download buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853421f4c74832498d14994e0b5a5bc